### PR TITLE
test: raise coverage for main sonar gate

### DIFF
--- a/tests/WebApiCoreSeed.UnitTests/Integracao/ProblemDetailsContractTests.cs
+++ b/tests/WebApiCoreSeed.UnitTests/Integracao/ProblemDetailsContractTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using WebApiCoreSeed.Api;
+using WebApiCoreSeed.Api.ViewModels;
 using WebApiCoreSeed.Identity.Infrastructure.Context;
 using WebApiCoreSeed.Api.Services.Interfaces;
 using WebApiCoreSeed.Api.Settings;
@@ -30,6 +31,7 @@ using WebApiCoreSeed.SampleRestaurant.Application.Contracts.Queries;
 using WebApiCoreSeed.SampleRestaurant.Interfaces.Pagination;
 using WebApiCoreSeed.SampleRestaurant.Interfaces.Repository;
 using WebApiCoreSeed.SampleRestaurant.Models;
+using WebApiCoreSeed.SampleRestaurant.Models.Enums;
 using WebApiCoreSeed.SampleRestaurant.Infrastructure.Context;
 using Xunit;
 
@@ -156,6 +158,119 @@ namespace WebApiCoreSeed.UnitTests.Integracao
                 ?? throw new InvalidOperationException("Expected response request URI.");
             Assert.Equal("/api/v1/Pratos/" + requestUri.Segments[^1], problem.GetProperty("instance").GetString());
             Assert.True(problem.TryGetProperty("traceId", out _));
+        }
+
+        [Fact]
+        public async Task ObterPratoExistenteDeveRetornarOk()
+        {
+            var prato = CreatePrato("Prato existente");
+            var repository = new StatefulPratoRepository(prato);
+            using var factory = new WebApiCoreSeedApiFactory(services =>
+            {
+                services.RemoveAll<IPratoRepository>();
+                services.AddSingleton<IPratoRepository>(repository);
+            });
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+
+            var json = await ReadJsonAsync(await client.GetAsync($"/api/v1/Pratos/{prato.Id}"), HttpStatusCode.OK);
+
+            Assert.Equal(prato.Id, json.GetProperty("id").GetGuid());
+            Assert.Equal("Prato existente", json.GetProperty("titulo").GetString());
+        }
+
+        [Fact]
+        public async Task AdicionarPratoValidoDeveRetornarCreatedComFotoGerada()
+        {
+            using var factory = new WebApiCoreSeedApiFactory();
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+
+            var response = await client.PostAsJsonAsync("/api/v1/Pratos", CreatePratoRequest());
+            var json = await ReadJsonAsync(response, HttpStatusCode.Created);
+            var data = json.GetProperty("data");
+
+            Assert.True(json.GetProperty("success").GetBoolean());
+            Assert.Equal("Prato HTTP", data.GetProperty("titulo").GetString());
+            Assert.EndsWith(".png", data.GetProperty("foto").GetString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task AdicionarPratoQuandoImagemAusenteDeveRetornarDomainProblemDetails()
+        {
+            using var factory = new WebApiCoreSeedApiFactory();
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+            var payload = CreatePratoRequest(fotoUpload: null);
+
+            var problem = await ReadProblemAsync(await client.PostAsJsonAsync("/api/v1/Pratos", payload), HttpStatusCode.BadRequest);
+
+            Assert.Equal("urn:problem:domain-rule", problem.GetProperty("type").GetString());
+            Assert.Contains("imagem", problem.GetProperty("errors").GetRawText(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task AdicionarPratoQuandoImagemNaoEhBase64DeveRetornarDomainProblemDetails()
+        {
+            using var factory = new WebApiCoreSeedApiFactory();
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+            var payload = CreatePratoRequest(fotoUpload: "nao-e-base64");
+
+            var problem = await ReadProblemAsync(await client.PostAsJsonAsync("/api/v1/Pratos", payload), HttpStatusCode.BadRequest);
+
+            Assert.Equal("urn:problem:domain-rule", problem.GetProperty("type").GetString());
+            Assert.Contains("Base64", problem.GetProperty("errors").GetRawText(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task AtualizarPratoQuandoIdDivergenteDeveRetornarDomainProblemDetails()
+        {
+            using var factory = new WebApiCoreSeedApiFactory();
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+            var payload = CreatePratoRequest();
+
+            var problem = await ReadProblemAsync(
+                await client.PutAsJsonAsync($"/api/v1/Pratos/{Guid.NewGuid()}", payload),
+                HttpStatusCode.BadRequest);
+
+            Assert.Equal("urn:problem:domain-rule", problem.GetProperty("type").GetString());
+            Assert.Contains("ids", problem.GetProperty("errors").GetRawText(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task AtualizarPratoExistenteDevePersistirAlteracoes()
+        {
+            var prato = CreatePrato("Prato anterior");
+            var repository = new StatefulPratoRepository(prato);
+            using var factory = new WebApiCoreSeedApiFactory(services =>
+            {
+                services.RemoveAll<IPratoRepository>();
+                services.AddSingleton<IPratoRepository>(repository);
+            });
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+            var payload = CreatePratoRequest(prato.Id, titulo: "Prato atualizado", foto: "atualizado.webp");
+
+            var response = await client.PutAsJsonAsync($"/api/v1/Pratos/{prato.Id}", payload);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.NotNull(repository.UpdatedPrato);
+            Assert.Equal("Prato atualizado", repository.UpdatedPrato.Titulo);
+            Assert.EndsWith(".png", repository.UpdatedPrato.Foto, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ExcluirPratoExistenteDeveRemoverComSucesso()
+        {
+            var prato = CreatePrato("Prato removido");
+            var repository = new StatefulPratoRepository(prato);
+            using var factory = new WebApiCoreSeedApiFactory(services =>
+            {
+                services.RemoveAll<IPratoRepository>();
+                services.AddSingleton<IPratoRepository>(repository);
+            });
+            using var client = factory.CreateApiClient(("Pratos", "*"));
+
+            var response = await client.DeleteAsync($"/api/v1/Pratos/{prato.Id}");
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Equal(prato.Id, repository.RemovedPratoId);
         }
 
         [Fact]
@@ -465,6 +580,40 @@ namespace WebApiCoreSeed.UnitTests.Integracao
             Assert.True(data.GetProperty("expiresIn").GetDouble() > 0);
         }
 
+        private static PratoRequestViewModel CreatePratoRequest(
+            Guid? id = null,
+            string titulo = "Prato HTTP",
+            string descricao = "Prato criado via teste HTTP.",
+            string? fotoUpload = "aW1hZ2VtLWRlLXRlc3Rl",
+            string foto = "prato.png")
+        {
+            return new PratoRequestViewModel
+            {
+                Id = id ?? Guid.NewGuid(),
+                Titulo = titulo,
+                Descricao = descricao,
+                FotoUpload = fotoUpload,
+                Foto = foto,
+                Preco = 25.5,
+                Ativo = true,
+                TipoPrato = ETipoPrato.Comida
+            };
+        }
+
+        private static Prato CreatePrato(string titulo)
+        {
+            return new Prato
+            {
+                Id = Guid.NewGuid(),
+                Titulo = titulo,
+                Descricao = "Prato existente para teste HTTP.",
+                Foto = "existente.png",
+                Preco = 42.5,
+                Ativo = true,
+                TipoPrato = ETipoPrato.Comida
+            };
+        }
+
         private static Action<NativeRateLimitingSettings> CreateRateLimitConfiguration(
             int publicPermitLimit = 3,
             int authenticatedPermitLimit = 3,
@@ -645,6 +794,78 @@ namespace WebApiCoreSeed.UnitTests.Integracao
 
             public Task<int> Contar(CancellationToken cancellationToken = default) => Task.FromResult(0);
 
+        }
+
+        private sealed class StatefulPratoRepository : IPratoRepository
+        {
+            private readonly Dictionary<Guid, Prato> _pratos;
+
+            public StatefulPratoRepository(params Prato[] pratos)
+            {
+                _pratos = pratos.ToDictionary(prato => prato.Id);
+            }
+
+            public Prato? UpdatedPrato { get; private set; }
+
+            public Guid? RemovedPratoId { get; private set; }
+
+            public Task Adicionar(Prato prato, CancellationToken cancellationToken = default)
+            {
+                _pratos[prato.Id] = prato;
+                return Task.CompletedTask;
+            }
+
+            public Task Atualizar(Prato prato, CancellationToken cancellationToken = default)
+            {
+                UpdatedPrato = prato;
+                _pratos[prato.Id] = prato;
+                return Task.CompletedTask;
+            }
+
+            public Task RemoverPorId(Guid id, CancellationToken cancellationToken = default)
+            {
+                RemovedPratoId = id;
+                _pratos.Remove(id);
+                return Task.CompletedTask;
+            }
+
+            public Task<Prato?> ObterPorId(Guid id, CancellationToken cancellationToken = default)
+            {
+                _pratos.TryGetValue(id, out var prato);
+                return Task.FromResult(prato);
+            }
+
+            public Task<bool> ExisteComId(Guid id, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(_pratos.ContainsKey(id));
+            }
+
+            public Task<IReadOnlyList<PratoListItem>> ListarPagina(PaginationParameter paginationParameter, CancellationToken cancellationToken = default)
+            {
+                var items = _pratos.Values
+                    .OrderBy(prato => prato.Titulo)
+                    .ThenBy(prato => prato.Id)
+                    .Skip((paginationParameter.PageNumber - 1) * paginationParameter.PageSize)
+                    .Take(paginationParameter.PageSize)
+                    .Select(prato => new PratoListItem
+                    {
+                        Id = prato.Id,
+                        Titulo = prato.Titulo,
+                        Descricao = prato.Descricao,
+                        Foto = prato.Foto,
+                        Preco = prato.Preco,
+                        Ativo = prato.Ativo,
+                        TipoPrato = prato.TipoPrato
+                    })
+                    .ToArray();
+
+                return Task.FromResult<IReadOnlyList<PratoListItem>>(items);
+            }
+
+            public Task<int> Contar(CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(_pratos.Count);
+            }
         }
 
         private sealed class FakeMesaRepository : IMesaRepository

--- a/tests/WebApiCoreSeed.UnitTests/Unitarios/Resources/HttpErrorMessagesTests.cs
+++ b/tests/WebApiCoreSeed.UnitTests/Unitarios/Resources/HttpErrorMessagesTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using WebApiCoreSeed.Api;
+using Xunit;
+
+namespace WebApiCoreSeed.UnitTests.Unitarios.Resources;
+
+public sealed class HttpErrorMessagesTests
+{
+    [Theory]
+    [InlineData(400, "sintaxe")]
+    [InlineData(401, "autenticado")]
+    [InlineData(403, "permiss")]
+    [InlineData(404, "encontrada")]
+    [InlineData(405, "suportado")]
+    [InlineData(418, "I'm a teapot")]
+    public void RetornaMensagemErroQuandoStatusConhecidoOuPadraoDeveRetornarMensagem(int statusCode, string expectedText)
+    {
+        var message = InvokeMessage(statusCode);
+
+        Assert.Contains(expectedText, message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string InvokeMessage(int statusCode)
+    {
+        var type = typeof(Program).Assembly.GetType("WebApiCoreSeed.Api.Resources.HttpErrorMessages", throwOnError: true)!;
+        var method = type.GetMethod("RetornaMensagemErro", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Metodo RetornaMensagemErro nao encontrado.");
+
+        return Assert.IsType<string>(method.Invoke(null, new object[] { statusCode }));
+    }
+}


### PR DESCRIPTION
﻿## Contexto

Acompanhei os jobs da `main` ap?s o merge do PR #31. O run de CI `32775947651` falhou apenas no job `SonarCloud Quality Gate`; o job independente de build, testes, OpenAPI, an?lise de pacotes e uploads passou. O CodeQL do mesmo commit passou no run `32775947666`.

O Quality Gate remoto do SonarCloud estava vermelho por cobertura nova abaixo do limite: `new_coverage = 75.0`, limite `80`. Duplica??o nova estava OK (`0.0`, limite `3`).

## Corre??o

- Adiciona cobertura HTTP para fluxos reais do `PratosController`: obter, adicionar, validar imagem ausente/inv?lida, atualizar e excluir.
- Adiciona cobertura direta para `HttpErrorMessages`, que tamb?m aparecia sem cobertura no novo c?digo.
- Mant?m o SonarCloud obrigat?rio: nenhuma condi??o de workflow foi enfraquecida e nenhum `continue-on-error` foi adicionado.

## Valida??o local

- `dotnet build WebApiCoreSeed.slnx --configuration Release --no-restore`
- `dotnet test tests/WebApiCoreSeed.UnitTests/WebApiCoreSeed.UnitTests.csproj --configuration Release --no-build --no-restore --logger "trx;LogFileName=unit-tests.pr.trx" --results-directory TestResults/Unit-Pr --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura,opencover "DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*.Test]*,[*.Tests]*,[*.UnitTests]*,[*.IntegrationTests]*" "DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile=**/*.generated.cs"`
- `dotnet test tests/WebApiCoreSeed.IntegrationTests/WebApiCoreSeed.IntegrationTests.csproj --configuration Release --no-build --no-restore`
- `dotnet run --project tools/OpenApiGenerator/OpenApiGenerator.csproj --configuration Release --no-build`
- valida??o JSON dos contratos OpenAPI
- `dotnet list WebApiCoreSeed.slnx package --vulnerable`
- `git diff --exit-code -- docs/openapi/openapi-v1.json docs/openapi/openapi-v2.json`
- `git diff --check`

O `pre-push` tamb?m executou restore, build e testes existentes em Debug com sucesso.

## Runs relacionados

- Main CI com falha no SonarCloud Quality Gate: https://github.com/rodri-oliveira-dev/web-api-core-seed/actions/runs/32775947651
- Main CodeQL aprovado: https://github.com/rodri-oliveira-dev/web-api-core-seed/actions/runs/32775947666

## Runs deste PR

- CI aprovado: https://github.com/rodri-oliveira-dev/web-api-core-seed/actions/runs/32777550710
- CodeQL aprovado: https://github.com/rodri-oliveira-dev/web-api-core-seed/actions/runs/32777550867
- Dependency Review aprovado: https://github.com/rodri-oliveira-dev/web-api-core-seed/actions/runs/32777550703
